### PR TITLE
优化全选本页功能

### DIFF
--- a/src/views/Achievement/Index.vue
+++ b/src/views/Achievement/Index.vue
@@ -165,8 +165,8 @@
                                 <div class="chk">
                                     <el-checkbox
                                         label="全选本页"
-                                        size="large"
                                         v-model="selectAllCat"
+                                        size="large"
                                         @change="(checked:boolean) => checkAllCat(checked)"
                                     />
                                 </div>

--- a/src/views/Achievement/Index.vue
+++ b/src/views/Achievement/Index.vue
@@ -163,7 +163,12 @@
                                     <el-checkbox v-model="hideFinished" label="隐藏已完成" size="large" />
                                 </div>
                                 <div class="chk">
-                                    <el-checkbox v-model="selectAllCat" @change="checked=>checkAllCat(checked)" label="全选本页" size="large" />
+                                    <el-checkbox
+                                        v-model="selectAllCat"
+                                        @change="(checked:boolean) => checkAllCat(checked)"
+                                        label="全选本页"
+                                        size="large"
+                                    />
                                 </div>
                             </div>
                             <div class="right" :class="{ [$style.searchToWrap]: searchTo && searchHidden && searchKw }">
@@ -478,8 +483,8 @@ export default defineComponent({
             const reloadAllCat = () => {
                 let reloadStatus = true
                 for (let i = 0; i < data.length; i++) {
-                    if(achievementFin.value[data[i].id]) {
-                        if(achievementFin.value[data[i].id].status === UIAFStatus.ACHIEVEMENT_UNFINISHED) {
+                    if (achievementFin.value[data[i].id]) {
+                        if (achievementFin.value[data[i].id].status === UIAFStatus.ACHIEVEMENT_UNFINISHED) {
                             reloadStatus = false
                             selectAllCat.value = false
                             return
@@ -490,7 +495,7 @@ export default defineComponent({
                         return
                     }
                 }
-                if(reloadStatus) {
+                if (reloadStatus) {
                     selectAllCat.value = true
                 }
             }
@@ -603,16 +608,19 @@ export default defineComponent({
             }
             return data
         })
-        const checkAllCat = (checked) => {
-            let data = currentCat.value.achievements.concat([])
-            if(checked) {
-                data.forEach(item => {
-                    store.value.achievement2[item.id] = AchievementItem.create(item.id, UIAFStatus.ACHIEVEMENT_POINT_TAKEN)
+        const checkAllCat = (checked: boolean) => {
+            const data = currentCat.value.achievements.concat([])
+            if (checked) {
+                data.forEach((item) => {
+                    store.value.achievement2[item.id] = AchievementItem.create(
+                        item.id,
+                        UIAFStatus.ACHIEVEMENT_POINT_TAKEN,
+                    )
                 })
                 selectAllCat.value = true
             }
-            if(!checked) {
-                data.forEach(item => {
+            if (!checked) {
+                data.forEach((item) => {
                     store.value.achievement2[item.id].status = UIAFStatus.ACHIEVEMENT_UNFINISHED
                 })
             }

--- a/src/views/Achievement/Index.vue
+++ b/src/views/Achievement/Index.vue
@@ -164,8 +164,8 @@
                                 </div>
                                 <div class="chk">
                                     <el-checkbox
-                                        label="全选本页"
                                         v-model="selectAllCat"
+                                        label="全选本页"
                                         size="large"
                                         @change="(checked:boolean) => checkAllCat(checked)"
                                     />

--- a/src/views/Achievement/Index.vue
+++ b/src/views/Achievement/Index.vue
@@ -164,10 +164,10 @@
                                 </div>
                                 <div class="chk">
                                     <el-checkbox
-                                        v-model="selectAllCat"
-                                        @change="(checked:boolean) => checkAllCat(checked)"
                                         label="全选本页"
                                         size="large"
+                                        v-model="selectAllCat"
+                                        @change="(checked:boolean) => checkAllCat(checked)"
                                     />
                                 </div>
                             </div>


### PR DESCRIPTION
1. 位置从底部移动到了头部, 在有很多成就的版块中需要往下滑动很久才能点击全选, 移动到头部使其操作更加方便.
2. 完善误操作撤回以及单点其中一个成就之后再点击全选本页无效的问题. 如果误点了全选本页, 那么只能单点一个个撤回, 然后再点击全选就失效了. 
3. 风险点提醒:  之前全选本页click函数中的或判断逻辑我去掉了683行的部分, 可能会产生未知影响.