### PR TITLE
🐞 fix: appearance

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2022-2023, YuehaiTeam
+Copyright (c) 2022-2024, YuehaiTeam
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/views/AchievementScanner/CaptureScanner/FloatContent2.vue
+++ b/src/views/AchievementScanner/CaptureScanner/FloatContent2.vue
@@ -65,7 +65,7 @@ export default defineComponent({
                 )
                 ctx.fillText(
                     '如需中断，请按 Win 键停止识别',
-                    (89 / 250) * canvas.value.width,
+                    (86 / 250) * canvas.value.width,
                     (88 / 250) * canvas.value.width,
                 )
             } else {

--- a/src/views/ArtifactScanner/CaptureScanner/Float.vue
+++ b/src/views/ArtifactScanner/CaptureScanner/Float.vue
@@ -65,7 +65,7 @@ export default defineComponent({
                 )
                 ctx.fillText(
                     '如需中断，请按 Win 键停止切换',
-                    (89 / 250) * canvas.value.width,
+                    (86 / 250) * canvas.value.width,
                     (88 / 250) * canvas.value.width,
                 )
             } else {

--- a/src/views/Options/Basic.vue
+++ b/src/views/Options/Basic.vue
@@ -41,7 +41,7 @@
         </el-form>
         <h4>关于</h4>
         <section class="about">
-            <div class="logo"><icon-cocogoat /> 椰羊cocogoat</div>
+            <div class="logo"><icon-cocogoat /> 椰羊 cocogoat</div>
             <div class="copyright">&copy;2022-2023 YuehaiTeam <build-info /></div>
             <div v-if="options.reporting" class="logreport">
                 <el-link @click="report">上传日志</el-link>
@@ -88,6 +88,7 @@ export default {
             width: 300px;
             max-width: 80%;
             align-items: center;
+            text-align: center;
             .logo {
                 height: 50px;
                 color: var(--c-text);

--- a/src/views/Options/Basic.vue
+++ b/src/views/Options/Basic.vue
@@ -42,7 +42,7 @@
         <h4>关于</h4>
         <section class="about">
             <div class="logo"><icon-cocogoat /> 椰羊 cocogoat</div>
-            <div class="copyright">&copy;2022-2023 YuehaiTeam <build-info /></div>
+            <div class="copyright">&copy;2022-2024 YuehaiTeam <build-info /></div>
             <div v-if="options.reporting" class="logreport">
                 <el-link @click="report">上传日志</el-link>
             </div>

--- a/src/views/Options/Index.vue
+++ b/src/views/Options/Index.vue
@@ -1,6 +1,6 @@
 <template>
     <Layout :class="$style.options">
-        <template #title>设置</template>
+        <template #title><span style="font-family: genshin">设置</span></template>
         <el-tabs :model-value="$route.name" @update:model-value="$router.replace({ name: $event })">
             <el-tab-pane name="options.basic" label="基本设置"></el-tab-pane>
             <el-tab-pane name="options.user" label="账号管理"></el-tab-pane>


### PR DESCRIPTION
# 修复了一些显示细节问题

## 设置页标题字体

调整了设置页面的标题的字体样式，与首页和成就页统一。

| 变更前 | 变更后 |
|:-----:|:-----:|
| ![title-before](https://github.com/YuehaiTeam/cocogoat/assets/15167799/c8ba3e18-af6d-43b3-b04a-2bd2045aa87c) | ![title-after](https://github.com/YuehaiTeam/cocogoat/assets/15167799/721011a0-8b47-4831-ad4e-91c6b8367a04) |

## 关于组件

关于组件内原单行文本现已溢出，设置文本居中，改善观感。

| 变更前 | 变更后 |
|:-----:|:-----:|
| ![about-before](https://github.com/YuehaiTeam/cocogoat/assets/15167799/13b2fcfc-2696-4b33-b621-595d9d9f8443) | ![about-after](https://github.com/YuehaiTeam/cocogoat/assets/15167799/1705295c-1213-4342-bfd7-656223d828bc) |

## 悬浮窗

之前我在 `Win` 两侧添加了空格，导致文案位置偏移，现已修复。

| 变更前 | 变更后 |
|:-----:|:-----:|
| ![float-before](https://github.com/YuehaiTeam/cocogoat/assets/15167799/e8b93ec1-e1dd-400b-84c4-e0373be9e1c4) | ![float-after](https://github.com/YuehaiTeam/cocogoat/assets/15167799/3baea6fa-b230-4f33-88b2-e218062dc63b) |