### PR TITLE
修复样式

### DIFF
--- a/src/components/UncompatibleDialog.vue
+++ b/src/components/UncompatibleDialog.vue
@@ -1,6 +1,6 @@
 <template>
     <el-dialog
-        custom-class="uncompatible-dialog"
+        class="uncompatible-dialog"
         title="当前浏览器版本过低"
         :modelValue="dialogVisible"
         :close-on-click-modal="false"

--- a/src/views/Achievement/AchievementDetail.vue
+++ b/src/views/Achievement/AchievementDetail.vue
@@ -4,7 +4,7 @@
         :model-value="!!achievement"
         :z-index="111"
         :width="500"
-        :custom-class="$style.detailDialog"
+        :class="$style.detailDialog"
         @closed="$emit('close')"
     >
         <div :class="$style.trigger">

--- a/src/views/Achievement/ExportDropdown.vue
+++ b/src/views/Achievement/ExportDropdown.vue
@@ -22,7 +22,7 @@
     <el-dialog
         v-model="exportData.show"
         :title="exportData.title"
-        :custom-class="$style.exportDialog"
+        :class="$style.exportDialog"
         append-to-body
         destroy-on-close
     >

--- a/src/views/Achievement/Index.vue
+++ b/src/views/Achievement/Index.vue
@@ -86,7 +86,7 @@
             </div>
         </template>
         <scanner-dialog v-model:showScanner="showScanner" />
-        <el-dialog v-model="showImport" title="导入" :custom-class="$style.importDialog" destroy-on-close>
+        <el-dialog v-model="showImport" title="导入" :class="$style.importDialog" destroy-on-close>
             <import-dialog :memo-id="autoImportId" @close="closeImport" />
         </el-dialog>
         <achievement-detail :achievement="detail" @close="detail = undefined" />

--- a/src/views/Achievement/ScannerDialog.vue
+++ b/src/views/Achievement/ScannerDialog.vue
@@ -10,7 +10,7 @@
     <el-dialog
         v-model="scannerResult.show"
         :title="`成功扫描 ${scannerResult.length} 个成就`"
-        :custom-class="$style.scannerResultDialog"
+        :class="$style.scannerResultDialog"
         destroy-on-close
     >
         以下为失败和识别到的未完成成就列表，您可以自行检查确认后手动添加。

--- a/src/views/Options/Sync.vue
+++ b/src/views/Options/Sync.vue
@@ -87,7 +87,7 @@
 
         <el-drawer
             :model-value="addType !== ''"
-            custom-class="add-drawer"
+            class="add-drawer"
             title="添加同步账号"
             :size="320"
             :append-to-body="false"

--- a/src/views/Options/User.vue
+++ b/src/views/Options/User.vue
@@ -45,7 +45,7 @@
         </el-table>
         <el-drawer
             v-model="edit.show"
-            custom-class="edit-drawer"
+            class="edit-drawer"
             :size="320"
             :title="`${edit.edit ? '编辑' : '添加'}账号`"
             :append-to-body="false"
@@ -269,7 +269,7 @@ export default defineComponent({
     }
 }
 .avatar-sel {
-    height: 57px;
+    height: 71px;
     overflow: hidden;
     .avatar-sel-prefix {
         border-radius: 100%;

--- a/vue.config.js
+++ b/vue.config.js
@@ -24,10 +24,10 @@ const usePreJS = process.argv.includes('--prejs') || false // isCI
 const useSWC = isCI
     ? 'false'
     : process.argv.includes('--no-swc')
-    ? 'false'
-    : process.argv.includes('--no-swc-minify')
-    ? 'compile'
-    : 'true'
+      ? 'false'
+      : process.argv.includes('--no-swc-minify')
+        ? 'compile'
+        : 'true'
 const useSentry = false
 // !process.argv.includes('--no-sentry') && process.env.NODE_ENV === 'production' && !!process.env.SENTRY_KEY
 process.env.VUE_APP_BUILD = require('dayjs')().format('YYMMDDHHmm')


### PR DESCRIPTION
在之前的 PR 中（<https://github.com/YuehaiTeam/cocogoat/pull/72>），由于更新 Element Plus 导致了部分样式被破坏，这个 PR 进行了修复。

> `custom-class` 已被 **弃用**, 之后将会在 `2.4.0` 移除, 请使用 `class`.
>
> <https://element-plus.org/zh-CN/component/dialog.html#attributes>

---

|缺少样式|尺寸不对|
|:-:|:-:|
|![](https://github.com/YuehaiTeam/cocogoat/assets/15167799/f4b20a0b-8d8e-4a1a-ad7d-e3ecb9bfb5c3)|![](https://github.com/YuehaiTeam/cocogoat/assets/15167799/48ac0651-2a28-4b7f-b96a-9d3982d8c0f8)|