### PR TITLE
修复样式

### DIFF
--- a/src/views/Achievement/ImportDialog.vue
+++ b/src/views/Achievement/ImportDialog.vue
@@ -1,6 +1,6 @@
 <template>
     <!-- eslint-disable vue/no-parsing-error -->
-    <div style="margin-top: -35px">
+    <div style="margin-top: -5px">
         <el-tabs v-model="activeName" stretch>
             <el-tab-pane label="本地导入" name="text">
                 <div
@@ -224,9 +224,9 @@ export default defineComponent({
 .import-button {
     display: block;
     margin-top: 15px;
-    width: calc(100% + 40px);
+    width: calc(100% + var(--el-dialog-padding-primary) * 2);
     margin-bottom: -30px;
-    margin-left: -20px;
+    margin-left: calc(-1 * var(--el-dialog-padding-primary));
     height: 50px;
     border-radius: 0;
     border-left: 0;

--- a/src/views/Achievement/Index.vue
+++ b/src/views/Achievement/Index.vue
@@ -27,7 +27,8 @@
                 <div class="a-line">
                     <el-popover
                         v-model:visible="showClear"
-                        :width="190"
+                        width="auto"
+                        trigger="click"
                         :placement="isMobile ? 'left-start' : 'bottom'"
                     >
                         <div style="text-align: center">真的要清空吗？</div>
@@ -37,7 +38,7 @@
                             <el-button size="small" type="danger" plain @click="doClear(true)">清空全部</el-button>
                         </div>
                         <template #reference>
-                            <el-button v-show="!showScanner" type="danger" plain @click="showClear = true">
+                            <el-button v-show="!showScanner" type="danger" plain>
                                 <fa-icon icon="trash-can" />
                                 清空
                             </el-button>

--- a/src/views/Options/Basic.vue
+++ b/src/views/Options/Basic.vue
@@ -1,8 +1,8 @@
 <template>
-    <section :class="$style.optionBasic">
+    <section :class="[$style.optionBasic, { [$style.optionBasicMoblie]: isMobile }]">
         <el-form label-position="right" label-width="130px">
             <el-form-item label="语言 (Language)">
-                <div>
+                <div class="form-content">
                     <div class="select">
                         <el-select v-model="options.lang">
                             <el-option v-for="(i, a) in langNames" :key="a" :label="i" :value="a" />
@@ -12,7 +12,7 @@
                 </div>
             </el-form-item>
             <el-form-item label="颜色模式">
-                <div>
+                <div class="form-content">
                     <div class="select">
                         <el-select v-model="configuredMode">
                             <el-option label="跟随系统" value="auto" />
@@ -23,7 +23,7 @@
                 </div>
             </el-form-item>
             <el-form-item label="错误报告和统计">
-                <div>
+                <div class="form-content">
                     <div class="select">
                         <el-switch v-model="options.reporting"></el-switch>
                     </div>
@@ -31,7 +31,7 @@
                 </div>
             </el-form-item>
             <el-form-item label="展示广告">
-                <div>
+                <div class="form-content">
                     <div class="select">
                         <el-switch v-model="options.showads"></el-switch>
                     </div>
@@ -51,6 +51,8 @@
 </template>
 
 <script>
+import { toRef } from 'vue'
+import bus from '@/bus'
 import { langNames } from '@/i18n'
 import { options } from '@/store'
 import { configuredMode } from '@/utils/darkmode'
@@ -67,6 +69,7 @@ export default {
             reporting.report()
         }
         return {
+            isMobile: toRef(bus(), 'isMobile'),
             langNames,
             options,
             report,
@@ -86,10 +89,8 @@ export default {
         .about {
             display: flex;
             flex-direction: column;
-            align-content: center;
             justify-content: center;
-            width: 300px;
-            max-width: 80%;
+            width: 320px;
             align-items: center;
             text-align: center;
             .logo {
@@ -116,6 +117,19 @@ export default {
             .logreport {
                 margin-top: 12px;
             }
+        }
+    }
+}
+.option-basic.option-basic-moblie {
+    :global {
+        .form-content {
+            width: 100%;
+        }
+        .select {
+            width: 100%;
+        }
+        .about {
+            width: 100%;
         }
     }
 }


### PR DESCRIPTION
在之前的 PR 中（<https://github.com/YuehaiTeam/cocogoat/pull/72>），由于更新 Element Plus 导致了部分样式被破坏，这个 PR 继续进行修复。

## 清空成就按钮

更新后由于 `el-popover` 中 `width` 属性发生变化，容器大小过小。现直接改为 `auto` 自适应。

| 更新依赖前 | 更新依赖后 | 此次修复后 |
| :-: | :-: | :-: |
| ![clear-origin](https://github.com/user-attachments/assets/845af30b-bb02-4680-a363-cfb2aa2ac6b7) | ![clear-before](https://github.com/user-attachments/assets/8b46b955-8ec5-40fb-aee0-b1bfede806d0) | ![clear-after](https://github.com/user-attachments/assets/5e729f7e-a72b-4a81-a762-ab422e8e79a4) |

## 导入成就对话框

同样是由于 Element Plus 对话框的样式有变，导致对话框底部蓝色按钮样式中一些硬编码的数值不再合适。现改为使用 Element Plus 的相关 CSS 变量进行计算。

| 更新依赖前 | 更新依赖后 | 此次修复后 |
| :-: | :-: | :-: |
| ![importdialog-origin](https://github.com/user-attachments/assets/c98dc76b-eb24-46eb-a952-6859838455ee) | ![importdialog-before](https://github.com/user-attachments/assets/035a1ed5-ac79-4cb2-be98-3ba4efa47bd5) | ![importdialog-after](https://github.com/user-attachments/assets/0dcd60b3-00a5-4300-add8-852b1e8ad207) |

## 基本设置

这个就不属于修复了，只是在检测到是移动端的时候把一些组件的宽度拉满，看起来好看一点。

| 此次修复前 | 此次修复后 |
| :-: | :-: |
| ![optionbasic-before](https://github.com/user-attachments/assets/bb37ff71-4611-4bfc-95ee-4f5472a21db5) | ![optionbasic-after](https://github.com/user-attachments/assets/00242aff-5aff-4adf-b3a8-9036cef81e68) |
