### PR TITLE
fix bug #137

### DIFF
--- a/src/views/Achievement/AchievementSidebar.vue
+++ b/src/views/Achievement/AchievementSidebar.vue
@@ -7,14 +7,14 @@
                         v-if="!hideFinished || (achievementFinStat[i.id || 0]?.count || 0) < i.achievements.length"
                         :to="{
                             params: {
-                                cat: i.key === 'wonders-of-the-world' ? '' : i.key,
+                                cat: i.key,
                             },
                         }"
-                        :active-class="i.key === 'wonders-of-the-world' ? '' : 'router-link-active'"
-                        :exact-active-class="i.key === 'wonders-of-the-world' ? 'router-link-active' : ''"
+                        :active-class="i.key === DEFAULTCAT ? '' : 'router-link-active'"
+                        :exact-active-class="i.key === DEFAULTCAT ? 'router-link-active' : ''"
                     >
                         <div>
-                            {{ amos[i.name] }}
+                            {{ i.key === ALLCAT ? '所有' : amos[i.name] }}
                         </div>
                         <small>
                             <b>
@@ -57,6 +57,9 @@ import type { ElScrollbar } from 'element-plus'
 export default defineComponent({
     props: ['achievementCat', 'achievementFinStat', 'hideFinished'],
     setup() {
+        const DEFAULTCAT = 'wonders-of-the-world'
+        const ALLCAT = 'all'
+
         const scrollbarRef = ref<InstanceType<typeof ElScrollbar> | null>(null)
         const move = (dir: number) => {
             if (!scrollbarRef.value) return
@@ -73,6 +76,8 @@ export default defineComponent({
             scrollbarRef,
             isMobile: toRef(bus(), 'isMobile'),
             amos: toRef(i18n, 'amos'),
+            DEFAULTCAT,
+            ALLCAT,
         }
     },
 })

--- a/src/views/Achievement/Index.vue
+++ b/src/views/Achievement/Index.vue
@@ -104,7 +104,7 @@
                 ></div>
             </div>
             <achievement-sidebar
-                :achievementCat="achievementCat"
+                :achievementCat="allAchievementCat"
                 :achievementFinStat="achievementFinStat"
                 :hideFinished="hideFinished"
             />
@@ -431,7 +431,17 @@ export default defineComponent({
                 .filter((e) => e.achievements.length > 0)
             return ach
         })
-
+        const allAchievementCat = computed(() => {
+            const output = []
+            const all = { id: -1, order: 0, key: 'all', name: -1, totalReward: 0, achievements: [] as Achievement[] }
+            achievementCat.value.forEach((e) => {
+                all.totalReward += e.totalReward
+                all.achievements.push(...e.achievements)
+            })
+            output.push(all)
+            output.push(...achievementCat.value)
+            return output
+        })
         const totalCount = computed(() => {
             return achievementCat.value.reduce((acc, e) => acc + e.achievements.length, 0)
         })
@@ -445,19 +455,11 @@ export default defineComponent({
         const DEFAULTCAT = 'wonders-of-the-world'
         const ALLCAT = 'all'
         const currentCatId = computed(() => {
-            return route.params.cat || ALLCAT
+            return route.params.cat || DEFAULTCAT
         })
         const currentCat = computed(() => {
-            let v: AchievementCategory
-            if (currentCatId.value === ALLCAT) {
-                v = { achievements: [], key: ALLCAT, id: 0, name: 0, order: 0, totalReward: 0 }
-                // 整合所有成就便于做整体的搜索
-                for (let i = 0; i < achievementCat.value.length; i++) {
-                    v.achievements.push(...achievementCat.value[i].achievements)
-                }
-            } else {
-                v = achievementCat.value.find((i) => i.key === currentCatId.value) || achievementCat.value[0]
-            }
+            const v: AchievementCategory =
+                allAchievementCat.value.find((i) => i.key === currentCatId.value) || achievementCat.value[0]
             const q = {} as Record<number, string>
             v.achievements.forEach((e) => {
                 if (e.trigger.task && e.trigger.task.length > 0) {
@@ -477,7 +479,6 @@ export default defineComponent({
             if (i18n.amos[ach.desc].toLowerCase().includes(search.toLowerCase())) return true
         }
         const searchToList = (search: string, cb: AutocompleteFetchSuggestionsCallback) => {
-            console.log(i18n.amos)
             return cb(
                 currentCat.value.achievements
                     .filter((e) => has(e, search))
@@ -767,6 +768,7 @@ export default defineComponent({
             showScanner,
             selectedIds,
             achievementCat,
+            allAchievementCat,
             currentCatId,
             currentCat,
             achievementFin,


### PR DESCRIPTION
主要解决了天动万象标签下默认显示所有成就的问题。
原思路是在未选中的情况下默认显示所有成就，尽可能少的改动原代码，使用感知上也没有差别。但是从实际使用上来看，确实直接显示所有标签更加直接。
在成就数组的基础上，加了个all形成新数组，成就完成度部分暂时未调试，下个改动验证相关内容