### PR TITLE
fix(AchievementSidebar): 修复“所有”模块的计数问题

### DIFF
--- a/src/views/Achievement/AchievementSidebar.vue
+++ b/src/views/Achievement/AchievementSidebar.vue
@@ -19,12 +19,22 @@
                         <small>
                             <b>
                                 <img :src="img('yuanshi')" alt="原石" />
-                                {{ achievementFinStat[i.id || 0]?.reward || 0 }}/{{ i.totalReward }}
+                                {{
+                                    i.key === ALLCAT
+                                        ? totalFin?.reward || 0
+                                        : achievementFinStat[i.id || 0]?.reward || 0
+                                }}/{{ i.totalReward }}
                             </b>
                             <span>
-                                {{ achievementFinStat[i.id || 0]?.count || 0 }}/{{ i.achievements.length }} ({{
-                                    Math.round(
-                                        ((achievementFinStat[i.id || 0]?.count || 0) / i.achievements.length) * 100,
+                                {{
+                                    i.key === ALLCAT ? totalFin?.count || 0 : achievementFinStat[i.id || 0]?.count || 0
+                                }}/{{ i.achievements.length }} ({{
+                                    Math.floor(
+                                        ((i.key === ALLCAT
+                                            ? totalFin?.count || 0
+                                            : achievementFinStat[i.id || 0]?.count || 0) /
+                                            i.achievements.length) *
+                                            100,
                                     )
                                 }}%)
                             </span>
@@ -55,7 +65,7 @@ import { i18n } from '@/i18n'
 import { ref, toRef, defineComponent } from 'vue'
 import type { ElScrollbar } from 'element-plus'
 export default defineComponent({
-    props: ['achievementCat', 'achievementFinStat', 'hideFinished'],
+    props: ['achievementCat', 'achievementFinStat', 'hideFinished', 'totalFin'],
     setup() {
         const DEFAULTCAT = 'wonders-of-the-world'
         const ALLCAT = 'all'

--- a/src/views/Achievement/Index.vue
+++ b/src/views/Achievement/Index.vue
@@ -104,6 +104,7 @@
                 ></div>
             </div>
             <achievement-sidebar
+                :totalFin="totalFin"
                 :achievementCat="allAchievementCat"
                 :achievementFinStat="achievementFinStat"
                 :hideFinished="hideFinished"


### PR DESCRIPTION
1、修复左侧“所有”一直显示为0的问题
![image](https://github.com/user-attachments/assets/a69c7b27-f6b0-4e5e-9108-ee75346a408f)

2、修改进度百分比的计算逻辑为向下取整